### PR TITLE
 ʾO-ʾƎgzǝʾǝtǝya Māryām stanzas of the miracles of Mary

### DIFF
--- a/new/LIT7498OEgzeteyaMaryam.xml
+++ b/new/LIT7498OEgzeteyaMaryam.xml
@@ -20,7 +20,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
                 <pubPlace>Hamburg</pubPlace>
                 <availability>
-                    <licence corresp="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                         licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
                 </availability>
             </publicationStmt>


### PR DESCRIPTION
I have created a new work record for the ʾO ʾƎgzǝʾǝtǝya Māryām stanzas, which correspond to the ʾAkko-nu Bǝʾsi stanzas (CAe 4274). The author composed poetic responses for only 27 out of the 32 regularly circulating miracles, omitting stanzas for the 18th miracle (on the two brother scribes), the 26th (on Bārok), the 30th (on the thief boy), the 31st (on the pregnant woman), and the 32nd (on the thirsty dog). Based on my recent findings, I have attributed the composition of these stanzas to the monk Wǝldä Kǝrǝstos, who is also known as the author of Malkǝʾa ʾAbbā Nob (see Getatchew Haile, 1994: “Builders of Churches and Authors of Hymns. Makers of History in the Ethiopian Church”), and have encoded this attribution in the <relation> element. In total, Wǝldä Kǝrǝstos composed around 55 stanzas, including the 27 ʾAkko-nu Bǝʾsi-type stanzas and others corresponding to additional Marian miracles (see EMML 8920: https://www.vhmml.org/readingRoom/view/201665). Some of these stanzas were later copied by other commissioners who added their names after the final verses—one of whom was Faqāda Kǝrǝstos, whose copy in logical order (1–27) is preserved in MS EMML 7366 and served as the source for this record; another commissioner named Qerǝlos also included some of these stanzas in MS Bǝḥerāwi Kǝllǝlāwi Mangǝśti Tǝgrāy, Č̣ahāt Mādhāne ʿĀlam (MAC-001).
I would be very grateful for any suggestions, improvements, or modifications you might recommend for this record.