### PR TITLE
Update LIT1927Mashaf

### DIFF
--- a/1001-2000/LIT1927Mashaf.xml
+++ b/1001-2000/LIT1927Mashaf.xml
@@ -44,6 +44,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <keywords>
                <term key="ChristianLiterature"/>
                <term key="Medicine"/>
+               <term key="Magic"/>
             </keywords>
          </textClass>
          <langUsage>


### PR DESCRIPTION
I updated titles, added abstract, keyword and edition to LIT1927Mashaf (Maṣḥafa Faws). To my surprise, I could not find an article about the Maṣḥafa Faws (Treatise of Therapeutics) in EAe, vol. 3 and 4. Possibly, it is among the Addenda in vol. 5, which is currently not available to me. I will check it, when I am in Hamburg again.