### PR TITLE
Added xml:id for editions in LIT7194MGAbraset

### DIFF
--- a/7001-8000/LIT7194MGAbraset.xml
+++ b/7001-8000/LIT7194MGAbraset.xml
@@ -59,6 +59,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
             <change who="DR" when="2024-12-13">Created entity based on incipit and bibliographic references.</change>
             <change when="2026-04-20" who="CH">Updated abstract, titles and text; deleted doublet LIT7809MaggMir.</change>
+            <change when="2026-04-20" who="CH">Created xml:id for editions</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -81,14 +82,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl><ptr target="bm:Strelcyn1976Catalogue"/><citedRange unit="page">9-16</citedRange></bibl>
                 </listBibl>
             </div>
-            <div type="edition" xml:lang="gez">
+            <div type="edition" xml:lang="gez" xml:id="Makweriya1976">
                 <note>The following incipit is taken from 
                     <bibl><ptr target="bm:Makweriya1976DersanaGabriel"/><citedRange unit="page">122</citedRange></bibl>.</note>
                 <ab>ተአምሪሁ፡ ለቅዱስ፡ ገብርኤል፡ ሊቀ፡ መላእክት፡ ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ፍቁሩ፡ ለዓለመ፡ ዓለም፡ አሜን። ወሀሎ፡ ፩፡ ንጉሥ፡ በአሐቲ፡ ሀገር፡ ወንግሥትሂ፡ ሀለወት፡ 
                     ወለተ፡ ንጉሥሂ፡ ምስለ፡ እማ፡ ንግሥት። ወሀሎ፡ በቤተ፡ ንጉሥ፡ ፩፡ ብእሲ፡ መሠርይ፡ ዘስሙ፡ አብራሲት፡ ወውእቱ፡ ብእሲ፡ ያስተሀይጽ፡ አዕይንቲሁ፡ ከመ፡ ይርአያ፡ ለይእቲ፡
                     ወለት። <gap reason="ellipsis"/></ab>
             </div>
-            <div type="edition">
+            <div type="edition" xml:id="ANL3">
                 <note>The following incipit is taken from <ref type="mss" corresp="ANLcr3"/> according to the catalogue description in
                     <bibl><ptr target="bm:Strelcyn1976Catalogue"/><citedRange unit="page">12</citedRange></bibl>.</note>
                 <div type="textpart" subtype="incipit" xml:lang="gez">


### PR DESCRIPTION
I created xml:id for editions as @eu-genia has requested  in https://github.com/BetaMasaheft/Works/pull/1988/changes/a703cf8c2027ce99d8760c325fec7c31452508e4#r3109457638.

I tried to avoid the id ANLcr3, because I think that this would possibly interfere with the ID of the manuscript.