### PR TITLE
Update LIT3186Meeraf.xml

### DIFF
--- a/3001-4000/LIT3186Meeraf.xml
+++ b/3001-4000/LIT3186Meeraf.xml
@@ -56,6 +56,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       <revisionDesc>
          <change who="PL" when="2016-07-26">Created XML record from Ethio authority google spreadsheet</change>
          <change who="MV" when="2017-04-03">Added keywords and incipit</change>
+         <change when="2026-06-30" who="CH">Corrected relations</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -379,14 +380,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </div>
          </div>
          <listRelation>
-            <relation name="ecrm:CLP46i_may_form_part_of" active="LIT2444Temher" passive="LIT3186Meeraf"></relation>
-            <relation name="ecrm:CLP46i_may_form_part_of" active="LIT1113Anqasa" passive="LIT3186Meeraf"></relation>
-            <relation name="ecrm:CLP46i_may_form_part_of" active="LIT2301Sebhat" passive="LIT3186Meeraf"></relation>
-            <relation name="ecrm:CLP46i_may_form_part_of" active="LIT2509Weddas" passive="LIT3186Meeraf"></relation>
-            <relation name="ecrm:CLP46i_may_form_part_of" active="LIT3188Liton" passive="LIT3186Meeraf"></relation>
-            <relation name="ecrm:CLP46i_may_form_part_of" active="LIT5646Mastagabe" passive="LIT3186Meeraf"></relation>
-            <relation name="ecrm:CLP46i_may_form_part_of" active="LIT2605Zayena" passive="LIT3186Meeraf"></relation>
-            <relation name="ecrm:CLP46i_may_form_part_of" active="LIT1714Kestat" passive="LIT3186Meeraf"></relation>
+            <relation name="saws:contains" active="LIT3186Meeraf" passive="LIT2444Temher"/>
+            <relation name="saws:contains" active="LIT3186Meeraf" passive="LIT1113Anqasa"/>
+            <relation name="saws:contains" active="LIT3186Meeraf" passive="LIT2301Sebhat"/>
+            <relation name="saws:contains" active="LIT3186Meeraf" passive="LIT2509Weddas"/>
+            <relation name="saws:contains" active="LIT3186Meeraf" passive="LIT3188Liton"/>
+            <relation name="saws:contains" active="LIT3186Meeraf" passive="LIT5646Mastagabe"/>
+            <relation name="saws:contains" active="LIT3186Meeraf" passive="LIT2605Zayena"/>
+            <relation name="saws:contains" active="LIT3186Meeraf" passive="LIT1714Kestat"/>
          </listRelation>
       </body>
    </text>


### PR DESCRIPTION
In each relation in relation desc, the active can only be filled by the ID of the record and the passive is filled by the ID of what it shall refer to. As far as I know, we use saws:contains, if a text does normally or may possibly contain another text.