### PR TITLE
test(smoke): add install smoke, migrate to the shared org workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,14 @@
+name: Install smoke
+
+# Scoped so a push to a PR branch doesn't also fire the push event -
+# push+pull_request both matching the same branch double-triggers this
+# workflow for the same commit.
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  smoke:
+    uses: BetaMasaheft/.github/.github/workflows/install-smoke.yml@main

--- a/build.xml
+++ b/build.xml
@@ -33,7 +33,7 @@
 			is forbidden in expath-pkg.xml. Instead, replace version=".*", but not in the XML header
 		-->
 		<replaceregex
-			pattern="(?&lt;!xml )version=&quot;.*&quot;"
+			pattern="(?&lt;!xml )version=&quot;[^&quot;]*&quot;"
 			replace="version=&quot;${app.version}&quot;" />
       </filterchain>
     </copy>
@@ -49,6 +49,7 @@
       <fileset dir=".">
         <exclude name="${build.dir}/**" />
         <exclude name=".github/**" />
+        <exclude name="test/**" />
         <exclude name="node_modules/**" />
         <exclude name=".gitignore" />
         <exclude name=".vscode/**" />


### PR DESCRIPTION
Adds an install smoke (jinks `01-smoke.bats` template) that actually autodeploys the built xar into a clean eXist - this repo's CI was validation-only (TEI schema) with no check that the package installs at all.

Running it immediately found a real bug: the `templates` ant target's version-token `replaceregex` is greedy (`version=".*"`) and swallows the adjacent `spec="1.0"` attribute since they share a line, corrupting every ant-built xar's expath-pkg.xml (a bare eXist then refuses to install it: "The element does not have an attribute spec"). Not previously caught because every current consumer (the old monolith Dockerfile, the new data.Dockerfile) zips the raw repo directly and never runs `ant`. Fixed by anchoring the regex to the nearest quote instead of matching greedily to end-of-line.

Since then, migrated onto BetaMasaheft/.github's shared `install-smoke.yml` reusable workflow (BetaMasaheft/.github#10, #11, #12) instead of a local job + bats copy - two real bugs found in that local copy (a `grep -c 'healthy'` substring match against Docker's `(unhealthy)` status; an overly strict exact-count assertion on the package-deployment log check) had to be hand-patched across all 10 sibling repos separately before centralizing, which is exactly the problem the shared workflow now solves. Also scopes the `push` trigger to `master`/`main` so a PR branch push doesn't double-fire this workflow via both `push` and `pull_request`.

Verified end-to-end in real CI (ant build -> xst install -> shared bats suite) before merging.

Refs BetaMasaheft/BetMas#122